### PR TITLE
Produce docker autoconfig logs

### DIFF
--- a/container/common/python3.yaml
+++ b/container/common/python3.yaml
@@ -18,5 +18,5 @@ commandTests:
   expectedOutput: ['Python 3.*.*']
 - name: 'apt-add-repo-check'
   command: 'apt-add-repository'
-  args: ['multiverse']
-  expectedOutput: ['.* distribution component is already enabled for all sources.']
+  args: ['-h']
+  expectedOutput: ['Usage: apt-add-repository']

--- a/container/common/python3.yaml
+++ b/container/common/python3.yaml
@@ -16,3 +16,7 @@ commandTests:
   command: 'python3'
   args: ['-V']
   expectedOutput: ['Python 3.*.*']
+- name: 'apt-add-repo-check'
+  command: 'apt-add-repository'
+  args: ['multiverse']
+  expectedOutput: ['.* distribution component is already enabled for all sources.']

--- a/container/common/python3_rbe.yaml
+++ b/container/common/python3_rbe.yaml
@@ -2,7 +2,7 @@ schemaVersion: "2.0.0"
 
 fileExistenceTests:
 - name: 'python3'
-  path: '/usr/bin/python3'
+  path: '/opt/python3.6/bin/python3'
   shouldExist: true
 - name: 'pycache3.5'
   path: '/usr/lib/python3.5/__pycache__'
@@ -15,4 +15,4 @@ commandTests:
 - name: 'python3-version'
   command: 'python3'
   args: ['-V']
-  expectedOutput: ['Python 3.*.*']
+  expectedOutput: ['Python 3.6.*']

--- a/container/debian8/builders/bazel/container.yaml
+++ b/container/debian8/builders/bazel/container.yaml
@@ -3,6 +3,6 @@ schemaVersion: "2.0.0"
 metadataTest:
   env:
     - key: 'PATH'
-      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin'
+      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   entrypoint: ["/usr/local/bin/bazel"]
   cmd: []

--- a/container/debian8/builders/rbe-debian8/BUILD
+++ b/container/debian8/builders/rbe-debian8/BUILD
@@ -65,7 +65,7 @@ toolchain_container(
         "//container/debian8/layers/go:go-ltl",
         "//container/debian8/layers/java:java-ltl",
         "//container/debian8/layers/java:java10-ltl",
-        "//container/debian8/layers/python:python-ltl",
+        "//container/debian8/layers/python:python-rbe-ltl",
     ],
 )
 
@@ -76,7 +76,7 @@ container_test(
         "//container/common:go.yaml",
         "//container/common:java.yaml",
         "//container/common:python2.yaml",
-        "//container/common:python3.yaml",
+        "//container/common:python3_rbe.yaml",
         "//container/common:rbe-base.yaml",
         "//container/common/clang:clang.yaml",
         "//container/debian8:debian8.yaml",

--- a/container/debian8/layers/python/BUILD
+++ b/container/debian8/layers/python/BUILD
@@ -55,7 +55,7 @@ language_tool_layer(
         "python-dev",
         "python-setuptools",
         "python3-dev",
-        "software-properties-common"
+        "software-properties-common",
     ],
     symlinks = {
         "/usr/bin/python": "/usr/bin/python2.7",

--- a/container/debian8/layers/python/BUILD
+++ b/container/debian8/layers/python/BUILD
@@ -26,7 +26,7 @@ PYTHON_CLEANUP_COMMANDS = (
 )
 
 language_tool_layer(
-    name = "python-ltl",
+    name = "python-rbe-ltl",
     base = "@debian8//image",
     env = {
         "PATH": "$PATH:/opt/python3.6/bin",
@@ -45,4 +45,19 @@ language_tool_layer(
         "/opt/python3.6/bin/easy_install3": "/opt/python3.6/bin/easy_install-3.6",
     },
     tars = ["//third_party/python:debian8_tar"],
+)
+
+language_tool_layer(
+    name = "python-ltl",
+    base = "@debian8//image",
+    installation_cleanup_commands = PYTHON_CLEANUP_COMMANDS,
+    packages = [
+        "python-dev",
+        "python-setuptools",
+        "python3-dev",
+        "software-properties-common"
+    ],
+    symlinks = {
+        "/usr/bin/python": "/usr/bin/python2.7",
+    },
 )

--- a/container/ubuntu14_04/builders/bazel/BUILD
+++ b/container/ubuntu14_04/builders/bazel/BUILD
@@ -74,6 +74,7 @@ language_tool_layer(
         ":container.yaml",
         "//container/common:java.yaml",
         "//container/common:python2.yaml",
+        "//container/common:python3.yaml",
         "//container/common/bazel:bazel_%s.yaml" % bazel_version,
         "//container/common/bazel:bazel_tools.yaml",
         "//container/common/bazel:extra_tools.yaml",

--- a/container/ubuntu14_04/layers/python/BUILD
+++ b/container/ubuntu14_04/layers/python/BUILD
@@ -31,6 +31,9 @@ language_tool_layer(
     installation_cleanup_commands = PYTHON_CLEANUP_COMMANDS,
     packages = [
         "python-dev",
+        "python-setuptools",
+        "python3-dev",
+        "software-properties-common",
     ],
     symlinks = {
         "/usr/bin/python": "/usr/bin/python2.7",

--- a/container/ubuntu16_04/builders/bazel/container.yaml
+++ b/container/ubuntu16_04/builders/bazel/container.yaml
@@ -3,6 +3,6 @@ schemaVersion: "2.0.0"
 metadataTest:
   env:
     - key: 'PATH'
-      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin'
+      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
   entrypoint: ["/usr/local/bin/bazel"]
   cmd: []

--- a/container/ubuntu16_04/builders/bazel_docker_gcloud/BUILD
+++ b/container/ubuntu16_04/builders/bazel_docker_gcloud/BUILD
@@ -69,7 +69,7 @@ language_tool_layer(
         ":container.yaml",
         "//container/common:java.yaml",
         "//container/common:python2.yaml",
-        "//container/common:python3.yaml",
+        "//container/common:python3_rbe.yaml",
         "//container/common/clang:clang.yaml",
         "//container/common/bazel:bazel_%s.yaml" % bazel_version,
         "//container/common/bazel:bazel_tools.yaml",

--- a/container/ubuntu16_04/builders/bazel_docker_gcloud/BUILD
+++ b/container/ubuntu16_04/builders/bazel_docker_gcloud/BUILD
@@ -54,7 +54,7 @@ language_tool_layer(
         "//container/ubuntu16_04/layers/clang:clang-ltl",
         "//container/ubuntu16_04/layers/java:java-ltl",
         "//container/ubuntu16_04/layers/java:java10-ltl",
-        "//container/ubuntu16_04/layers/python:python-ltl",
+        "//container/ubuntu16_04/layers/python:python-rbe-ltl",
         "//container/ubuntu16_04/layers/bazel:bazel-tools",
         "//container/ubuntu16_04/layers/bazel:bazel_%s-ltl" % bazel_version,
         "//container/ubuntu16_04/layers/docker-17.12.0:docker-ltl",

--- a/container/ubuntu16_04/builders/bazel_docker_gcloud/container.yaml
+++ b/container/ubuntu16_04/builders/bazel_docker_gcloud/container.yaml
@@ -3,4 +3,4 @@ schemaVersion: "2.0.0"
 metadataTest:
   env:
     - key: 'PATH'
-      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin'
+      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/container/ubuntu16_04/builders/bazel_docker_gcloud/container.yaml
+++ b/container/ubuntu16_04/builders/bazel_docker_gcloud/container.yaml
@@ -3,4 +3,4 @@ schemaVersion: "2.0.0"
 metadataTest:
   env:
     - key: 'PATH'
-      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+      value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin'

--- a/container/ubuntu16_04/builders/rbe-ubuntu16_04/BUILD
+++ b/container/ubuntu16_04/builders/rbe-ubuntu16_04/BUILD
@@ -67,7 +67,7 @@ toolchain_container(
         "//container/ubuntu16_04/layers/go:go-ltl",
         "//container/ubuntu16_04/layers/java:java-ltl",
         "//container/ubuntu16_04/layers/java:java10-ltl",
-        "//container/ubuntu16_04/layers/python:python-ltl",
+        "//container/ubuntu16_04/layers/python:python-rbe-ltl",
     ],
 )
 
@@ -78,7 +78,7 @@ container_test(
         "//container/common:go.yaml",
         "//container/common:java.yaml",
         "//container/common:python2.yaml",
-        "//container/common:python3.yaml",
+        "//container/common:python3_rbe.yaml",
         "//container/common:rbe-base.yaml",
         "//container/common/clang:clang.yaml",
         "//container/ubuntu16_04:ubuntu16_04.yaml",

--- a/container/ubuntu16_04/layers/python/BUILD
+++ b/container/ubuntu16_04/layers/python/BUILD
@@ -26,7 +26,7 @@ PYTHON_CLEANUP_COMMANDS = (
 )
 
 language_tool_layer(
-    name = "python-ltl",
+    name = "python-rbe-ltl",
     base = "@ubuntu16_04//image",
     env = {
         "PATH": "$PATH:/opt/python3.6/bin",
@@ -45,4 +45,19 @@ language_tool_layer(
         "/opt/python3.6/bin/easy_install3": "/opt/python3.6/bin/easy_install-3.6",
     },
     tars = ["//third_party/python:ubuntu16_04_tar"],
+)
+
+language_tool_layer(
+    name = "python-ltl",
+    base = "@ubuntu16_04//image",
+    installation_cleanup_commands = PYTHON_CLEANUP_COMMANDS,
+    packages = [
+        "python-dev",
+        "python-setuptools",
+        "python3-dev",
+        "software-properties-common",
+    ],
+    symlinks = {
+        "/usr/bin/python": "/usr/bin/python2.7",
+    },
 )


### PR DESCRIPTION
Docker autoconfig is not printing out anywhere the results of executing commands inside the container. This PR adds a new output to the rule that produces the log. 
Example outputs produced by an autoconfig rule:
Target //tests/config:ubuntu-xenial-autoconfig up-to-date:
  bazel-bin/tests/config/ubuntu-xenial-autoconfig-layer.tar
  bazel-bin/tests/config/ubuntu-xenial-autoconfig.tar
  bazel-bin/tests/config/ubuntu-xenial-autoconfig.digest
  bazel-bin/tests/config/ubuntu-xenial-autoconfig_log.log
  bazel-bin/tests/config/ubuntu-xenial-autoconfig_outputs.tar
